### PR TITLE
Support compiling with gcc15

### DIFF
--- a/classes/old-kernel-gcc-hdrs.bbclass
+++ b/classes/old-kernel-gcc-hdrs.bbclass
@@ -13,5 +13,6 @@ do_configure:prepend() {
     echo "#include <linux/compiler-gcc11.h>" > ${S}/include/linux/compiler-gcc12.h
     echo "#include <linux/compiler-gcc12.h>" > ${S}/include/linux/compiler-gcc13.h
     echo "#include <linux/compiler-gcc13.h>" > ${S}/include/linux/compiler-gcc14.h
+    echo "#include <linux/compiler-gcc14.h>" > ${S}/include/linux/compiler-gcc15.h
 }
 

--- a/classes/old-kernel-gcc-hdrs.bbclass
+++ b/classes/old-kernel-gcc-hdrs.bbclass
@@ -16,3 +16,6 @@ do_configure:prepend() {
     echo "#include <linux/compiler-gcc14.h>" > ${S}/include/linux/compiler-gcc15.h
 }
 
+do_install:prepend() {
+    export HOST_EXTRACFLAGS="--std=gnu17"
+}

--- a/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
+++ b/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
@@ -34,8 +34,9 @@ python do_generate_config () {
                 v = var
             if d.getVar(var) is not None:
                 config.set(key, v, str(d.getVar(var)))
-
-    with open(d.getVar('UNPACKDIR') + "/machine.conf", "w") as machine_conf:
+    unpackdir = d.getVar('UNPACKDIR')
+    os.makedirs(unpackdir, exist_ok=True)
+    with open(f"{unpackdir}/machine.conf", "w") as machine_conf:
         config.write(machine_conf)
 }
 

--- a/recipes-extended/bash/bash_%.bbappend
+++ b/recipes-extended/bash/bash_%.bbappend
@@ -1,0 +1,1 @@
+BUILD_CFLAGS += "-std=gnu17"


### PR DESCRIPTION
This adds support for compiling with gcc15 (now the default on Fedora).  Not everything is complete yet, but this is a start.